### PR TITLE
在庫変動の可視化と入金管理を強化

### DIFF
--- a/assets/js/inventory-and-stock.js
+++ b/assets/js/inventory-and-stock.js
@@ -5,24 +5,112 @@
  * @deps wp-element, wp-api-fetch, wp-i18n, wp-components
  */
 
-const { useState } = wp.element;
-const { Button } = wp.components;
+const { useState, useEffect } = wp.element;
+const { Button, SelectControl, Flex, FlexItem } = wp.components;
 const { __, sprintf } = wp.i18n;
 
 const InventoryAndStock = ( props ) => {
 	const { inventory, onChange } = props;
-	const [ loading, setLoading ] = useState( false, [] );
-	if ( inventory.applied_at ) {
+	const [ loading, setLoading ] = useState( false );
+	const [ appliedAt, setAppliedAt ] = useState( inventory.applied_at );
+	const [ variations, setVariations ] = useState( null );
+	const [ selectedVariationId, setSelectedVariationId ] = useState( 0 );
+
+	const isVariable = 'variable' === inventory.product_type;
+
+	useEffect( () => {
+		if ( appliedAt || ! isVariable || ! inventory.parent_id ) {
+			return;
+		}
+		wp.apiFetch( {
+			path: '/hanmoto/v1/products/' + inventory.parent_id + '/variations',
+		} ).then( setVariations ).catch( () => {
+			setVariations( [] );
+		} );
+	}, [ isVariable, inventory.parent_id, appliedAt ] );
+
+	if ( appliedAt ) {
 		return (
 			// translators: %s is the date when the inventory was applied.
-			<span style={ { color: 'lightgrey' } }>{ sprintf( __( '%sに在庫反映済み', 'hametuha' ), inventory.applied_at ) }</span>
+			<span style={ { color: 'lightgrey' } }>{ sprintf( __( '%sに在庫反映済み', 'hametuha' ), appliedAt ) }</span>
 		);
 	}
+
+	const applyStock = ( variationId ) => {
+		setLoading( true );
+		wp.apiFetch( {
+			path: '/hanmoto/v1/inventory/' + inventory.id + '/',
+			method: 'POST',
+			data: variationId ? { variation_id: variationId } : {},
+		} ).then( ( data ) => {
+			setAppliedAt( data.updated );
+			onChange( { ...inventory, applied_at: data.updated } );
+		} ).catch( ( error ) => {
+			alert( error.message );
+		} ).finally( () => {
+			setLoading( false );
+		} );
+	};
+
+	if ( isVariable ) {
+		if ( null === variations ) {
+			return (
+				<span style={ { color: 'lightgrey' } }>{ __( 'バリエーション取得中…', 'hanmoto' ) }</span>
+			);
+		}
+		if ( 0 === variations.length ) {
+			return (
+				<span style={ { color: 'lightgrey' } }>{ __( 'バリエーションがありません', 'hanmoto' ) }</span>
+			);
+		}
+		const options = [
+			{ value: 0, label: __( '反映先バリエーション', 'hanmoto' ) },
+			...variations.map( ( v ) => {
+				let label;
+				if ( v.managing_stock ) {
+					label = sprintf(
+						// translators: %1$s is variation name, %2$d is current stock.
+						__( '%1$s (在庫: %2$d)', 'hanmoto' ),
+						v.name,
+						v.stock || 0
+					);
+				} else {
+					label = sprintf(
+						// translators: %s is variation name.
+						__( '%s (在庫管理なし)', 'hanmoto' ),
+						v.name
+					);
+				}
+				return { value: v.id, label };
+			} ),
+		];
+		return (
+			<Flex align="center" justify="flex-start" gap={ 2 }>
+				<FlexItem>
+					<SelectControl
+						value={ selectedVariationId }
+						options={ options }
+						onChange={ ( id ) => setSelectedVariationId( parseInt( id ) ) }
+					/>
+				</FlexItem>
+				<FlexItem>
+					<Button
+						isSecondary
+						isSmall
+						disabled={ loading || ! selectedVariationId }
+						onClick={ () => applyStock( selectedVariationId ) }
+					>
+						{ __( '在庫に反映', 'hanmoto' ) }
+					</Button>
+				</FlexItem>
+			</Flex>
+		);
+	}
+
 	return (
-		<Button isSecondary disabled={ loading } isSmall onClick={ () => {
-			setLoading( true );
-			onChange( inventory );
-		} }>{ __( '在庫に反映', 'hanmoto' ) }</Button>
+		<Button isSecondary disabled={ loading } isSmall onClick={ () => applyStock( 0 ) }>
+			{ __( '在庫に反映', 'hanmoto' ) }
+		</Button>
 	);
 };
 

--- a/assets/js/inventory-bulk-action.js
+++ b/assets/js/inventory-bulk-action.js
@@ -8,35 +8,112 @@
 const { __, sprintf } = wp.i18n;
 const $ = jQuery;
 
+/**
+ * Show a native <dialog> asking for the realized-at date.
+ *
+ * @param {number} count Number of selected inventories.
+ * @returns {Promise<string|null>} Resolves to selected Y-m-d string, or null if cancelled.
+ */
+function askRealizedAt( count ) {
+	return new Promise( ( resolve ) => {
+		const today = new Date().toISOString().slice( 0, 10 );
+		// translators: %d is the number of selected inventories.
+		const description = sprintf( __( '選択された %d 件の取引に実現日を設定します。', 'hanmoto' ), count );
+		const titleText = __( '実現日を一括設定', 'hanmoto' );
+		const labelText = __( '実現日', 'hanmoto' );
+		const cancelText = __( 'キャンセル', 'hanmoto' );
+		const confirmText = __( '設定する', 'hanmoto' );
+		const dialog = document.createElement( 'dialog' );
+		dialog.style.padding = '20px';
+		dialog.style.minWidth = '320px';
+		dialog.style.border = '1px solid #c3c4c7';
+		dialog.style.borderRadius = '4px';
+		dialog.innerHTML = `
+			<form method="dialog" style="display: flex; flex-direction: column; gap: 12px; margin: 0;">
+				<h2 style="margin: 0; font-size: 1.2em;">${ titleText }</h2>
+				<p style="margin: 0;">${ description }</p>
+				<p style="margin: 0;">
+					<label>${ labelText }:
+						<input type="date" name="realized_at" value="${ today }" required style="margin-left: 6px;" />
+					</label>
+				</p>
+				<p style="margin: 0; text-align: right;">
+					<button type="button" data-action="cancel" class="button" style="margin-right: 6px;">${ cancelText }</button>
+					<button type="submit" value="confirm" class="button button-primary">${ confirmText }</button>
+				</p>
+			</form>
+		`;
+		document.body.appendChild( dialog );
+		dialog.querySelector( '[data-action="cancel"]' ).addEventListener( 'click', () => {
+			dialog.close( 'cancel' );
+		} );
+		dialog.addEventListener( 'close', () => {
+			const value = dialog.querySelector( 'input[name="realized_at"]' ).value;
+			const result = dialog.returnValue;
+			document.body.removeChild( dialog );
+			resolve( 'confirm' === result ? value : null );
+		} );
+		dialog.showModal();
+	} );
+}
+
 $( document ).ready( function() {
 	$( '#doaction, #doaction2' ).click( function( e ) {
-		const $select = $( this ).prevAll( 'select[name="action"]' );
-		if ( 'assign-event' !== $select.val() ) {
-			return true;
-		}
-		e.preventDefault();
+		const $select = $( this ).prevAll( 'select[name^="action"]' );
+		const action = $select.val();
 		const $ids = $( '.wp-list-table input[name="post[]"]:checked' );
-		if ( ! $ids.length ) {
-			return true;
+		if ( 'assign-event' === action ) {
+			e.preventDefault();
+			if ( ! $ids.length ) {
+				return;
+			}
+			const request = [];
+			$ids.each( function( index, id ) {
+				request.push( $( id ).val() );
+			} );
+			const event = window.prompt( __( '割り当てる取引イベントのIDを指定してください。', 'hanmoto' ) );
+			if ( ! /^\d+$/.test( event ) ) {
+				return;
+			}
+			wp.apiFetch( {
+				path: 'hanmoto/v1/inventories/' + event + '/?ids=' + request.join( ',' ),
+				method: 'PUT',
+			} ).then( function( response ) {
+				// translators: %1$d is success, %2$d is total.
+				alert( sprintf( __( '%1$d/%2$d件を登録しました。', 'hanmoto' ), response.updated, response.should ) );
+				window.location.reload();
+			} ).catch( function( response ) {
+				alert( response.message );
+			} );
+			return;
 		}
-		const request = [];
-		$ids.each( function( index, id ) {
-			request.push( $( id ).val() );
-		} );
-		const event = window.prompt( __( '割り当てる取引イベントのIDを指定してください。', 'hanmoto' ) );
-		if ( ! /^\d+$/.test( event ) ) {
-			return true;
+		if ( 'set_realized_at' === action ) {
+			e.preventDefault();
+			if ( ! $ids.length ) {
+				return;
+			}
+			const ids = $ids.map( function( index, el ) {
+				return $( el ).val();
+			} ).get();
+			askRealizedAt( ids.length ).then( ( realizedAt ) => {
+				if ( null === realizedAt ) {
+					return;
+				}
+				wp.apiFetch( {
+					path: '/hanmoto/v1/inventories/bulk-realize',
+					method: 'POST',
+					data: {
+						ids: ids.join( ',' ),
+						realized_at: realizedAt,
+					},
+				} ).then( ( response ) => {
+					// translators: %1$d is success count, %2$d is total count.
+					alert( sprintf( __( '%1$d/%2$d件の実現日を設定しました。', 'hanmoto' ), response.updated, response.should ) );
+					window.location.reload();
+				} ).catch( ( err ) => {
+					alert( err.message );
+				} );
+			} );
 		}
-		wp.apiFetch( {
-			path: 'hanmoto/v1/inventories/' + event + '/?ids=' + request.join( ',' ),
-			method: 'PUT',
-		} ).then( function( response ) {
-			// translators: %1$d is success, %2$d is total.
-			alert( sprintf( __( '%1$d/%2$d件を登録しました。', 'hanmoto' ), response.updated, response.should ) );
-			window.location.reload();
-		} ).cache( function( response ) {
-			alert( response.message );
-		} );
 	} );
 } );
-

--- a/assets/js/inventory-helper.js
+++ b/assets/js/inventory-helper.js
@@ -115,22 +115,8 @@ const InventoryContainer = ( { post } ) => {
 										× { inventory.amount }冊（料率{ inventory.margin }%）</small>
 									＝<span style={ { color: ( subtotal > 0 ? 'green' : 'red' ) } }>&yen; { subtotal }</span>
 									<span>（{ inventory.transaction_type_label } @ { inventory.capture_at }）</span>
-									<InventoryAndStock inventory={ inventory } onChange={ ( inventoryToUpdate ) => {
-										wp.apiFetch( {
-											path: '/hanmoto/v1/inventory/' + inventoryToUpdate.id + '/',
-											method: 'POST',
-										} ).then( ( data ) => {
-											const newInventories = [];
-											for ( const i of inventories ) {
-												if ( i.id === inventoryToUpdate.id ) {
-													i.applied_at = data.updated;
-												}
-												newInventories.push( i );
-											}
-											setInventories( newInventories );
-										} ).catch( ( error ) => {
-											alert( error.message );
-										} );
+									<InventoryAndStock inventory={ inventory } onChange={ ( updated ) => {
+										setInventories( inventories.map( ( i ) => i.id === updated.id ? updated : i ) );
 									} } />
 								</li>
 							);

--- a/src/Hametuha/HanmotoHelper/Models/ModelEvent.php
+++ b/src/Hametuha/HanmotoHelper/Models/ModelEvent.php
@@ -90,6 +90,44 @@ class ModelEvent extends Singleton {
 				},
 			],
 		] );
+		// Variations of a variable product.
+		register_rest_route( 'hanmoto/v1', 'products/(?P<product_id>\d+)/variations', [
+			[
+				'methods'             => 'GET',
+				'args'                => [
+					'product_id' => [
+						'required'          => true,
+						'type'              => 'integer',
+						'validate_callback' => function ( $id ) {
+							return get_post( $id ) && 'product' === get_post_type( $id );
+						},
+					],
+				],
+				'permission_callback' => function () {
+					return current_user_can( 'edit_posts' );
+				},
+				'callback'            => function ( \WP_REST_Request $request ) {
+					$product = wc_get_product( $request->get_param( 'product_id' ) );
+					if ( ! $product || ! $product->is_type( 'variable' ) ) {
+						return new \WP_REST_Response( [] );
+					}
+					$items = [];
+					foreach ( $product->get_children() as $child_id ) {
+						$variation = wc_get_product( $child_id );
+						if ( ! $variation instanceof \WC_Product_Variation ) {
+							continue;
+						}
+						$items[] = [
+							'id'             => $variation->get_id(),
+							'name'           => wp_strip_all_tags( wc_get_formatted_variation( $variation, true ) ),
+							'stock'          => $variation->get_stock_quantity(),
+							'managing_stock' => $variation->managing_stock(),
+						];
+					}
+					return new \WP_REST_Response( $items );
+				},
+			],
+		] );
 		// Inventory list
 		$arg_post_id         = [
 			'type'                => 'int',

--- a/src/Hametuha/HanmotoHelper/Models/ModelInventory.php
+++ b/src/Hametuha/HanmotoHelper/Models/ModelInventory.php
@@ -46,8 +46,68 @@ class ModelInventory extends Singleton {
 		add_action( 'pre_get_posts', [ $this, 'filter_by_realized_status' ] );
 		// Bulk action.
 		add_filter( 'bulk_actions-edit-inventory', [ $this, 'add_bulk_actions' ] );
+		// Statistics above list table.
+		add_action( 'manage_posts_extra_tablenav', [ $this, 'render_inventory_stats' ] );
 		// REST API
 		add_action( 'rest_api_init', [ $this, 'register_apis' ] );
+	}
+
+	/**
+	 * Render aggregated stats above the inventory list table.
+	 *
+	 * @param string $which 'top' or 'bottom'.
+	 * @return void
+	 */
+	public function render_inventory_stats( $which ) {
+		if ( 'top' !== $which ) {
+			return;
+		}
+		$screen = get_current_screen();
+		if ( ! $screen || 'edit-inventory' !== $screen->id ) {
+			return;
+		}
+		global $wp_query;
+		if ( ! $wp_query instanceof \WP_Query ) {
+			return;
+		}
+		$args                   = $wp_query->query_vars;
+		$args['nopaging']       = true;
+		$args['posts_per_page'] = -1;
+		$args['fields']         = 'ids';
+		unset( $args['paged'], $args['offset'] );
+		$all = new \WP_Query( $args );
+		if ( empty( $all->posts ) ) {
+			return;
+		}
+		update_meta_cache( 'post', $all->posts );
+		$total_amount = 0;
+		$total_price  = 0;
+		foreach ( $all->posts as $id ) {
+			$total_amount += (int) get_post_meta( $id, '_amount', true );
+			$total_price  += $this->get_total( $id );
+		}
+		$amount_color = ( 0 > $total_amount ) ? 'red' : 'green';
+		$price_color  = ( 0 > $total_price ) ? 'red' : 'green';
+		?>
+		<div class="alignleft actions hanmoto-inventory-stats" style="margin-left: 8px;">
+			<strong><?php esc_html_e( '統計：', 'hanmoto' ); ?></strong>
+			<span style="margin-left: 6px;">
+				<?php esc_html_e( '在庫変動', 'hanmoto' ); ?>:
+				<strong style="color: <?php echo esc_attr( $amount_color ); ?>;">
+					<?php echo esc_html( number_format( $total_amount ) ); ?>
+				</strong>
+			</span>
+			<span style="margin-left: 12px;">
+				<?php esc_html_e( '総額', 'hanmoto' ); ?>:
+				<strong style="color: <?php echo esc_attr( $price_color ); ?>;">
+					&yen;<?php echo esc_html( number_format( (int) $total_price ) ); ?>
+				</strong>
+			</span>
+			<span style="margin-left: 12px; color: #666;">
+				(<?php echo esc_html( number_format( $all->found_posts ) ); ?><?php esc_html_e( '件', 'hanmoto' ); ?>)
+			</span>
+		</div>
+		<?php
 	}
 
 	/**

--- a/src/Hametuha/HanmotoHelper/Models/ModelInventory.php
+++ b/src/Hametuha/HanmotoHelper/Models/ModelInventory.php
@@ -134,6 +134,14 @@ class ModelInventory extends Singleton {
 							return is_numeric( $var ) && ( 'inventory' === get_post_type( $var ) );
 						},
 					],
+					'variation_id' => [
+						'required'          => false,
+						'type'              => 'integer',
+						'default'           => 0,
+						'validate_callback' => function ( $var ) {
+							return is_numeric( $var ) && ( 0 === (int) $var || 'product_variation' === get_post_type( $var ) );
+						},
+					],
 				],
 				'permission_callback' => function ( $request ) {
 					return current_user_can( 'edit_post', $request->get_param( 'inventory_id' ) );
@@ -146,8 +154,16 @@ class ModelInventory extends Singleton {
 						// translators: %s is updated time.
 						return new \WP_Error( 'already_applied', sprintf( __( '既に在庫反映されています: %s', 'hanmoto' ), $updated ), [ 'status' => 400 ] );
 					}
-					// Get product.
-					$product = wc_get_product( $inventory->post_parent );
+					// Get product (or selected variation).
+					$variation_id = (int) $request->get_param( 'variation_id' );
+					if ( $variation_id ) {
+						$product = wc_get_product( $variation_id );
+						if ( ! $product || ! $product->is_type( 'variation' ) || $product->get_parent_id() !== (int) $inventory->post_parent ) {
+							return new \WP_Error( 'invalid_variation', __( '不正なバリエーションが指定されました。', 'hanmoto' ), [ 'status' => 400 ] );
+						}
+					} else {
+						$product = wc_get_product( $inventory->post_parent );
+					}
 					if ( ! $product ) {
 						return new \WP_Error( 'not_found', __( '商品が見つかりませんでした。', 'hanmoto' ), [ 'status' => 404 ] );
 					}
@@ -156,18 +172,19 @@ class ModelInventory extends Singleton {
 						return new \WP_Error( 'stock_is_not_managed', __( 'この商品は在庫管理対象外です。', 'hanmoto' ), [ 'status' => 400 ] );
 					}
 					// 在庫情報を取得
-					$difference =
-					$old_stock  = $product->get_stock_quantity();
-					$new_stock  = $old_stock + (int) get_post_meta( $inventory->ID, '_amount', true );
-					$result     = wc_update_product_stock( $product->get_id(), $new_stock );
-					if ( ! $result ) {
+					$old_stock = $product->get_stock_quantity();
+					$new_stock = $old_stock + (int) get_post_meta( $inventory->ID, '_amount', true );
+					// wc_update_product_stock は更新後の在庫数を返すため、0冊になるケースで失敗扱いしないよう厳密比較する。
+					$result = wc_update_product_stock( $product->get_id(), $new_stock );
+					if ( false === $result ) {
 						return new \WP_Error( 'stock_manage_failed', __( '商品の在庫設定に失敗しました。', 'hanmoto' ), [ 'status' => 400 ] );
 					}
-					update_post_meta( $inventory->ID, '_applied_at', current_time( 'mysql' ) );
+					$applied_at = current_time( 'mysql' );
+					update_post_meta( $inventory->ID, '_applied_at', $applied_at );
 					return new \WP_REST_Response( [
 						'before'  => $old_stock,
 						'after'   => $new_stock,
-						'updated' => date_i18n( get_option( 'date_format' ) ),
+						'updated' => $applied_at,
 					] );
 				},
 			],
@@ -190,10 +207,13 @@ class ModelInventory extends Singleton {
 		if ( ! $parent ) {
 			return new \WP_Error( 'not_found', __( '商品が見つかりませんでした。', 'hanmoto' ), [ 'status' => 404 ] );
 		}
-		$response = [
-			'id'      => $post->ID,
-			'name'    => get_the_title( $post ),
-			'product' => get_the_title( $post->post_parent ),
+		$product_obj = wc_get_product( $post->post_parent );
+		$response    = [
+			'id'           => $post->ID,
+			'name'         => get_the_title( $post ),
+			'product'      => get_the_title( $post->post_parent ),
+			'parent_id'    => (int) $post->post_parent,
+			'product_type' => $product_obj ? $product_obj->get_type() : '',
 		];
 		foreach ( array_merge( $this->keys(), [ 'group' ] ) as $key ) {
 			$value = get_post_meta( $post->ID, '_' . $key, true );
@@ -335,7 +355,7 @@ class ModelInventory extends Singleton {
 			</table>
 			<p>
 				<label>
-					<?php esc_html_e( '請求日', 'hanmoto' ); ?><br />
+					<?php esc_html_e( '請求〆日', 'hanmoto' ); ?><br />
 					<input type="date" name="capture_at" value="<?php echo esc_attr( get_post_meta( $post->ID, '_capture_at', true ) ); ?>" />
 				</label>
 				<span style="display: inline-block; margin-left: 10px;">
@@ -366,18 +386,31 @@ class ModelInventory extends Singleton {
 				</span>
 			</p>
 			<p>
-				<label style="display: block">
+				<label style="display: inline-block">
 					<?php esc_html_e( '商品', 'hanmoto' ); ?>
 					<br />
 					<?php $this->book_select_pull_down( $post->post_parent ); ?>
-				</label>
-				<label style="marign-left: 10px;">
-					<?php
-					$applied_at = get_post_meta( $post->ID, '_applied_at', true );
-					if ( $applied_at ) :
-						?>
-						<span style="color: lightgrey;"><?php echo date_i18n( get_option( 'date_format' ), $applied_at ); ?></span>
-					<?php endif; ?>
+					<span style="margin-left: 10px;">
+						<?php
+						$applied_at = get_post_meta( $post->ID, '_applied_at', true );
+						if ( $applied_at ) :
+							?>
+							<span style="color: green;">
+								<span class="dashicons dashicons-yes"></span>
+								<?php
+								printf(
+									// translators: %s is the date when the inventory was applied.
+									esc_html__( '在庫反映済（%s）', 'hanmoto' ),
+									esc_html( date_i18n( get_option( 'date_format' ), $applied_at ) )
+								);
+								?>
+							</span>
+						<?php else : ?>
+							<span style="color: lightgrey;">
+								<?php esc_html_e( '在庫未反映', 'hanmoto' ); ?>
+							</span>
+						<?php endif; ?>
+					</span>
 				</label>
 			</p>
 			<p>

--- a/src/Hametuha/HanmotoHelper/Models/ModelInventory.php
+++ b/src/Hametuha/HanmotoHelper/Models/ModelInventory.php
@@ -41,8 +41,88 @@ class ModelInventory extends Singleton {
 		} );
 		// Customize admin columns.
 		$this->admin_columns( 'inventory' );
+		// Filter by realization status.
+		add_action( 'restrict_manage_posts', [ $this, 'render_realized_filter' ] );
+		add_action( 'pre_get_posts', [ $this, 'filter_by_realized_status' ] );
+		// Bulk action.
+		add_filter( 'bulk_actions-edit-inventory', [ $this, 'add_bulk_actions' ] );
 		// REST API
 		add_action( 'rest_api_init', [ $this, 'register_apis' ] );
+	}
+
+	/**
+	 * Add bulk action for setting realized date.
+	 *
+	 * @param array $actions Bulk actions on inventory list screen.
+	 * @return array
+	 */
+	public function add_bulk_actions( $actions ) {
+		$actions['set_realized_at'] = __( '実現日を設定', 'hanmoto' );
+		return $actions;
+	}
+
+	/**
+	 * Render dropdown filter for realization status on inventory list screen.
+	 *
+	 * @param string $post_type Current admin list post type.
+	 * @return void
+	 */
+	public function render_realized_filter( $post_type ) {
+		if ( 'inventory' !== $post_type ) {
+			return;
+		}
+		$current = filter_input( INPUT_GET, 'realized_status' );
+		?>
+		<select name="realized_status" aria-label="<?php esc_attr_e( '実現状況で絞り込み', 'hanmoto' ); ?>">
+			<option value=""><?php esc_html_e( '実現状況：すべて', 'hanmoto' ); ?></option>
+			<option value="unrealized" <?php selected( $current, 'unrealized' ); ?>><?php esc_html_e( '未実現の取引', 'hanmoto' ); ?></option>
+			<option value="realized" <?php selected( $current, 'realized' ); ?>><?php esc_html_e( '実現済みの取引', 'hanmoto' ); ?></option>
+		</select>
+		<?php
+	}
+
+	/**
+	 * Apply meta_query for realization status on inventory list screen.
+	 *
+	 * @param \WP_Query $query Main query in admin list.
+	 * @return void
+	 */
+	public function filter_by_realized_status( $query ) {
+		if ( ! is_admin() || ! $query->is_main_query() ) {
+			return;
+		}
+		if ( 'inventory' !== $query->get( 'post_type' ) ) {
+			return;
+		}
+		$status = filter_input( INPUT_GET, 'realized_status' );
+		if ( ! $status ) {
+			return;
+		}
+		$meta_query = $query->get( 'meta_query' );
+		if ( ! is_array( $meta_query ) ) {
+			$meta_query = [];
+		}
+		if ( 'unrealized' === $status ) {
+			$meta_query[] = [
+				'relation' => 'OR',
+				[
+					'key'     => '_realized_at',
+					'compare' => 'NOT EXISTS',
+				],
+				[
+					'key'     => '_realized_at',
+					'value'   => '',
+					'compare' => '=',
+				],
+			];
+		} elseif ( 'realized' === $status ) {
+			$meta_query[] = [
+				'key'     => '_realized_at',
+				'value'   => '',
+				'compare' => '!=',
+			];
+		}
+		$query->set( 'meta_query', $meta_query );
 	}
 
 
@@ -59,6 +139,7 @@ class ModelInventory extends Singleton {
 			'vat',
 			'capture_at',
 			'applied_at',
+			'realized_at',
 		];
 	}
 
@@ -189,6 +270,57 @@ class ModelInventory extends Singleton {
 				},
 			],
 		] );
+		// Bulk update realized_at.
+		register_rest_route( 'hanmoto/v1', 'inventories/bulk-realize', [
+			[
+				'methods'             => 'POST',
+				'args'                => [
+					'ids'         => [
+						'required'          => true,
+						'type'              => 'string',
+						'description'       => __( '対象在庫変動IDのカンマ区切り', 'hanmoto' ),
+						'validate_callback' => function ( $ids ) {
+							return is_string( $ids ) && (bool) preg_match( '/^\d+(,\d+)*$/', $ids );
+						},
+					],
+					'realized_at' => [
+						'required'          => true,
+						'type'              => 'string',
+						'description'       => __( '実現日 (Y-m-d) 。空文字を渡すと未設定に戻す', 'hanmoto' ),
+						'validate_callback' => function ( $date ) {
+							return is_string( $date ) && ( '' === $date || (bool) preg_match( '/^\d{4}-\d{2}-\d{2}$/', $date ) );
+						},
+					],
+				],
+				'permission_callback' => function () {
+					return current_user_can( 'edit_posts' );
+				},
+				'callback'            => function ( \WP_REST_Request $request ) {
+					$ids         = explode( ',', $request->get_param( 'ids' ) );
+					$realized_at = $request->get_param( 'realized_at' );
+					$updated     = 0;
+					foreach ( $ids as $id ) {
+						$id = (int) $id;
+						if ( 'inventory' !== get_post_type( $id ) ) {
+							continue;
+						}
+						if ( ! current_user_can( 'edit_post', $id ) ) {
+							continue;
+						}
+						if ( '' === $realized_at ) {
+							delete_post_meta( $id, '_realized_at' );
+						} else {
+							update_post_meta( $id, '_realized_at', $realized_at );
+						}
+						++$updated;
+					}
+					return new \WP_REST_Response( [
+						'updated' => $updated,
+						'should'  => count( $ids ),
+					] );
+				},
+			],
+		] );
 	}
 
 	/**
@@ -249,9 +381,13 @@ class ModelInventory extends Singleton {
 		if ( ! wp_verify_nonce( filter_input( INPUT_POST, '_hanmotoinventorynonce' ), 'update_inventory' ) ) {
 			return;
 		}
-		// Save all meta.
+		// Save all meta. フォームに含まれないキー（applied_at など REST 経由で更新するもの）はスキップする。
 		foreach ( $this->keys() as $key ) {
-			update_post_meta( $post_id, '_' . $key, filter_input( INPUT_POST, $key ) );
+			$value = filter_input( INPUT_POST, $key );
+			if ( null === $value ) {
+				continue;
+			}
+			update_post_meta( $post_id, '_' . $key, $value );
 		}
 		update_post_meta( $post_id, '_group', (int) filter_input( INPUT_POST, 'group' ) );
 	}
@@ -358,6 +494,16 @@ class ModelInventory extends Singleton {
 					<?php esc_html_e( '請求〆日', 'hanmoto' ); ?><br />
 					<input type="date" name="capture_at" value="<?php echo esc_attr( get_post_meta( $post->ID, '_capture_at', true ) ); ?>" />
 				</label>
+				<?php
+				$capture_at_value  = get_post_meta( $post->ID, '_capture_at', true );
+				$realized_at_value = get_post_meta( $post->ID, '_realized_at', true );
+				if ( $capture_at_value && ! $realized_at_value && $capture_at_value < current_time( 'Y-m-d' ) ) :
+					?>
+					<span style="color: #e67e22; font-weight: bold; margin-left: 10px;">
+						<span class="dashicons dashicons-calendar" style="vertical-align: text-bottom;"></span>
+						<?php esc_html_e( '請求〆日を過ぎています。入金を確認のうえ実現日を入力してください。', 'hanmoto' ); ?>
+					</span>
+				<?php endif; ?>
 				<span style="display: inline-block; margin-left: 10px;">
 				<?php
 				$dates = [
@@ -383,6 +529,15 @@ class ModelInventory extends Singleton {
 						<code><?php echo esc_html( $date ); ?></code>
 					</span>
 				<?php endforeach; ?>
+				</span>
+			</p>
+			<p>
+				<label>
+					<?php esc_html_e( '実現日', 'hanmoto' ); ?><br />
+					<input type="date" name="realized_at" value="<?php echo esc_attr( get_post_meta( $post->ID, '_realized_at', true ) ); ?>" />
+				</label>
+				<span class="description" style="display: inline-block; margin-left: 10px;">
+					<?php esc_html_e( '入金が完了した日付を入力すると「実現済み」になります。', 'hanmoto' ); ?>
 				</span>
 			</p>
 			<p>

--- a/src/Hametuha/HanmotoHelper/Utility/BookSelector.php
+++ b/src/Hametuha/HanmotoHelper/Utility/BookSelector.php
@@ -130,6 +130,9 @@ trait BookSelector {
 				.wp-list-table th.column-applied {
 					width: 110px;
 				}
+				.wp-list-table th.column-realized {
+					width: 110px;
+				}
 			</style>
 			<?php
 		} );
@@ -176,6 +179,7 @@ trait BookSelector {
 							default:
 								$new_columns['capture_at'] = __( '請求〆日', 'hanmoto' );
 								$new_columns['applied']    = __( '在庫反映', 'hanmoto' );
+								$new_columns['realized']   = __( '実現日', 'hanmoto' );
 								break 2;
 						}
 					default:
@@ -239,6 +243,25 @@ trait BookSelector {
 						);
 					} else {
 						printf( '<span style="color: lightgrey;">%s</span>', esc_html__( '未反映', 'hanmoto' ) );
+					}
+					break;
+				case 'realized':
+					$realized_at = get_post_meta( $post_id, '_realized_at', true );
+					if ( $realized_at ) {
+						printf(
+							'<span style="color: green;">%s</span>',
+							esc_html( mysql2date( __( 'Y年m月d日', 'hanmoto' ), $realized_at ) )
+						);
+					} else {
+						$capture_at = get_post_meta( $post_id, '_capture_at', true );
+						if ( $capture_at && $capture_at < current_time( 'Y-m-d' ) ) {
+							printf(
+								'<span style="color: #e67e22; font-weight: bold;"><span class="dashicons dashicons-calendar" style="vertical-align: text-bottom;"></span> %s</span>',
+								esc_html__( '〆日超過', 'hanmoto' )
+							);
+						} else {
+							printf( '<span style="color: lightgrey;">%s</span>', esc_html__( '未実現', 'hanmoto' ) );
+						}
 					}
 					break;
 			}

--- a/src/Hametuha/HanmotoHelper/Utility/BookSelector.php
+++ b/src/Hametuha/HanmotoHelper/Utility/BookSelector.php
@@ -174,7 +174,7 @@ trait BookSelector {
 								// Do nothing.
 								break 2;
 							default:
-								$new_columns['capture_at'] = __( '請求日', 'hanmoto' );
+								$new_columns['capture_at'] = __( '請求〆日', 'hanmoto' );
 								$new_columns['applied']    = __( '在庫反映', 'hanmoto' );
 								break 2;
 						}

--- a/src/Hametuha/HanmotoHelper/Utility/BookSelector.php
+++ b/src/Hametuha/HanmotoHelper/Utility/BookSelector.php
@@ -127,6 +127,9 @@ trait BookSelector {
 				.wp-list-table th.column-capture_at {
 					width: 14%;
 				}
+				.wp-list-table th.column-applied {
+					width: 110px;
+				}
 			</style>
 			<?php
 		} );
@@ -172,6 +175,7 @@ trait BookSelector {
 								break 2;
 							default:
 								$new_columns['capture_at'] = __( '請求日', 'hanmoto' );
+								$new_columns['applied']    = __( '在庫反映', 'hanmoto' );
 								break 2;
 						}
 					default:
@@ -224,6 +228,18 @@ trait BookSelector {
 				case 'shipped_at':
 					$capture_at = get_post_meta( $post_id, '_' . $column, true );
 					echo $capture_at ? mysql2date( __( 'Y年m月d日', 'hanmoto' ), $capture_at ) : '<span style="color:lightgrey">---</spans>';
+					break;
+				case 'applied':
+					$applied_at = get_post_meta( $post_id, '_applied_at', true );
+					if ( $applied_at ) {
+						printf(
+							'<span style="color: green;">%s<br /><small style="color: #666;">%s</small></span>',
+							esc_html__( '反映済', 'hanmoto' ),
+							esc_html( mysql2date( get_option( 'date_format' ), $applied_at ) )
+						);
+					} else {
+						printf( '<span style="color: lightgrey;">%s</span>', esc_html__( '未反映', 'hanmoto' ) );
+					}
 					break;
 			}
 		}, 10, 2 );


### PR DESCRIPTION
## Summary
- バリエーション商品の在庫反映に対応し、在庫反映ボタン周辺の不具合を修正
- 在庫変動の管理向けに「在庫反映」「実現日」カラムと一覧上部の統計表示を追加
- 「未実現の取引」「実現済みの取引」絞り込み、`_realized_at` の一括設定 bulk action、〆日超過のオレンジ警告など、入金状況把握のためのUIを整備

## 含まれるコミット
- `0e7204b` 在庫変動一覧に「在庫反映」カラムを追加
- `d59fcb5` バリエーション商品の在庫反映対応と関連不具合の修正（`wc_update_product_stock` の戻り値判定バグ、JSローディング状態リセット、metaboxのtypo、translatorsコメント位置 等）
- `694afb5` 在庫変動の実現日管理と一括設定UIを追加（postmeta `_realized_at`、絞り込み、〆日超過警告、bulk-realize REST APIとネイティブ`<dialog>`、`save_inventory_boxes` が REST 専用メタを巻き戻すバグ修正）
- `8c3e5a8` 在庫変動一覧上部に統計（在庫変動・総額・件数）を表示

## 主なAPI/UI追加
- `POST /hanmoto/v1/inventory/{id}` に `variation_id` 引数追加
- `GET /hanmoto/v1/products/{id}/variations` 新規
- `POST /hanmoto/v1/inventories/bulk-realize` 新規
- inventory `to_rest_response` に `product_type` / `parent_id` 追加
- 一覧の `views_edit-inventory` 上部 tablenav に集計表示
- inventory編集メタボックスに「実現日」フィールド + 〆日超過オレンジ警告

## Test plan
- [ ] simple商品の inventory で「在庫に反映」を押下し、`_applied_at` が記録され在庫が更新される
- [ ] **在庫が0冊になる**ケースでも「失敗しました」エラーにならない（旧バグの再現確認）
- [ ] variable 親に紐づく inventory で variation 選択ドロップダウン + 反映が動作する
- [ ] 反映後、APIエラー時もボタンが再度押せる（ローディング解除）
- [ ] 在庫変動一覧に「在庫反映」「実現日」カラムが見える
- [ ] 「実現状況」フィルタで「未実現」「実現済み」で絞り込める
- [ ] 未実現かつ請求〆日が今日未満の行は「実現日」カラムがオレンジ + dashicons-calendar で表示される
- [ ] 編集画面でも同じ条件でオレンジ警告が出る
- [ ] 一括アクション「実現日を設定」を選び「適用」→ ダイアログで日付編集 →「設定する」で更新後リロード、キャンセルで何も起こらない
- [ ] 一覧上部に「統計： 在庫変動 X / 総額 ¥Y (Z件)」が表示され、絞り込み結果に追従する

🤖 Generated with [Claude Code](https://claude.com/claude-code)