### PR TITLE
在庫変動の絞り込みを日付比較ベース化＋〆日・実現日の範囲指定

### DIFF
--- a/src/Hametuha/HanmotoHelper/Models/ModelInventory.php
+++ b/src/Hametuha/HanmotoHelper/Models/ModelInventory.php
@@ -89,7 +89,7 @@ class ModelInventory extends Singleton {
 		$amount_color = ( 0 > $total_amount ) ? 'red' : 'green';
 		$price_color  = ( 0 > $total_price ) ? 'red' : 'green';
 		?>
-		<div class="alignleft actions hanmoto-inventory-stats" style="margin-left: 8px;">
+		<div class="actions hanmoto-inventory-stats" style="margin-left: 8px; clear:left; padding-top: 10px;">
 			<strong><?php esc_html_e( '統計：', 'hanmoto' ); ?></strong>
 			<span style="margin-left: 6px;">
 				<?php esc_html_e( '在庫変動', 'hanmoto' ); ?>:
@@ -131,13 +131,29 @@ class ModelInventory extends Singleton {
 		if ( 'inventory' !== $post_type ) {
 			return;
 		}
-		$current = filter_input( INPUT_GET, 'realized_status' );
+		$current       = filter_input( INPUT_GET, 'realized_status' );
+		$capture_from  = filter_input( INPUT_GET, 'capture_at_from' );
+		$capture_to    = filter_input( INPUT_GET, 'capture_at_to' );
+		$realized_from = filter_input( INPUT_GET, 'realized_at_from' );
+		$realized_to   = filter_input( INPUT_GET, 'realized_at_to' );
 		?>
 		<select name="realized_status" aria-label="<?php esc_attr_e( '実現状況で絞り込み', 'hanmoto' ); ?>">
 			<option value=""><?php esc_html_e( '実現状況：すべて', 'hanmoto' ); ?></option>
 			<option value="unrealized" <?php selected( $current, 'unrealized' ); ?>><?php esc_html_e( '未実現の取引', 'hanmoto' ); ?></option>
 			<option value="realized" <?php selected( $current, 'realized' ); ?>><?php esc_html_e( '実現済みの取引', 'hanmoto' ); ?></option>
 		</select>
+		<label style="margin-left: 6px;">
+			<?php esc_html_e( '請求〆日', 'hanmoto' ); ?>
+			<input type="date" name="capture_at_from" value="<?php echo esc_attr( $capture_from ); ?>" aria-label="<?php esc_attr_e( '請求〆日の開始', 'hanmoto' ); ?>" />
+			<span>〜</span>
+			<input type="date" name="capture_at_to" value="<?php echo esc_attr( $capture_to ); ?>" aria-label="<?php esc_attr_e( '請求〆日の終了', 'hanmoto' ); ?>" />
+		</label>
+		<label style="margin-left: 6px;">
+			<?php esc_html_e( '実現日', 'hanmoto' ); ?>
+			<input type="date" name="realized_at_from" value="<?php echo esc_attr( $realized_from ); ?>" aria-label="<?php esc_attr_e( '実現日の開始', 'hanmoto' ); ?>" />
+			<span>〜</span>
+			<input type="date" name="realized_at_to" value="<?php echo esc_attr( $realized_to ); ?>" aria-label="<?php esc_attr_e( '実現日の終了', 'hanmoto' ); ?>" />
+		</label>
 		<?php
 	}
 
@@ -154,14 +170,13 @@ class ModelInventory extends Singleton {
 		if ( 'inventory' !== $query->get( 'post_type' ) ) {
 			return;
 		}
-		$status = filter_input( INPUT_GET, 'realized_status' );
-		if ( ! $status ) {
-			return;
-		}
 		$meta_query = $query->get( 'meta_query' );
 		if ( ! is_array( $meta_query ) ) {
 			$meta_query = [];
 		}
+		$today  = current_time( 'Y-m-d' );
+		$status = filter_input( INPUT_GET, 'realized_status' );
+		// 未実現: _realized_at が空 / 未設定 / 今日より未来。実現済み: _realized_at が今日以前。
 		if ( 'unrealized' === $status ) {
 			$meta_query[] = [
 				'relation' => 'OR',
@@ -174,13 +189,51 @@ class ModelInventory extends Singleton {
 					'value'   => '',
 					'compare' => '=',
 				],
+				[
+					'key'     => '_realized_at',
+					'value'   => $today,
+					'compare' => '>',
+					'type'    => 'DATE',
+				],
 			];
 		} elseif ( 'realized' === $status ) {
 			$meta_query[] = [
-				'key'     => '_realized_at',
-				'value'   => '',
-				'compare' => '!=',
+				'relation' => 'AND',
+				[
+					'key'     => '_realized_at',
+					'value'   => '',
+					'compare' => '!=',
+				],
+				[
+					'key'     => '_realized_at',
+					'value'   => $today,
+					'compare' => '<=',
+					'type'    => 'DATE',
+				],
 			];
+		}
+		// 日付範囲指定（請求〆日・実現日）。
+		foreach ( [ 'capture_at', 'realized_at' ] as $key ) {
+			$from = filter_input( INPUT_GET, $key . '_from' );
+			$to   = filter_input( INPUT_GET, $key . '_to' );
+			if ( empty( $from ) && empty( $to ) ) {
+				continue;
+			}
+			$clause = [
+				'key'  => '_' . $key,
+				'type' => 'DATE',
+			];
+			if ( ! empty( $from ) && ! empty( $to ) ) {
+				$clause['compare'] = 'BETWEEN';
+				$clause['value']   = [ $from, $to ];
+			} elseif ( ! empty( $from ) ) {
+				$clause['compare'] = '>=';
+				$clause['value']   = $from;
+			} else {
+				$clause['compare'] = '<=';
+				$clause['value']   = $to;
+			}
+			$meta_query[] = $clause;
 		}
 		$query->set( 'meta_query', $meta_query );
 	}

--- a/src/Hametuha/HanmotoHelper/Utility/BookSelector.php
+++ b/src/Hametuha/HanmotoHelper/Utility/BookSelector.php
@@ -247,14 +247,21 @@ trait BookSelector {
 					break;
 				case 'realized':
 					$realized_at = get_post_meta( $post_id, '_realized_at', true );
-					if ( $realized_at ) {
+					$today_ymd   = current_time( 'Y-m-d' );
+					if ( $realized_at && $realized_at <= $today_ymd ) {
 						printf(
 							'<span style="color: green;">%s</span>',
 							esc_html( mysql2date( __( 'Y年m月d日', 'hanmoto' ), $realized_at ) )
 						);
+					} elseif ( $realized_at ) {
+						printf(
+							'<span style="color: #666;"><span class="dashicons dashicons-calendar" style="vertical-align: text-bottom;"></span> %1$s<br /><small>%2$s</small></span>',
+							esc_html__( '実現予定', 'hanmoto' ),
+							esc_html( mysql2date( __( 'Y年m月d日', 'hanmoto' ), $realized_at ) )
+						);
 					} else {
 						$capture_at = get_post_meta( $post_id, '_capture_at', true );
-						if ( $capture_at && $capture_at < current_time( 'Y-m-d' ) ) {
+						if ( $capture_at && $capture_at < $today_ymd ) {
 							printf(
 								'<span style="color: #e67e22; font-weight: bold;"><span class="dashicons dashicons-calendar" style="vertical-align: text-bottom;"></span> %s</span>',
 								esc_html__( '〆日超過', 'hanmoto' )


### PR DESCRIPTION
## Summary
- 「未実現／実現済み」の判定を `_realized_at` と当日の **日付比較** に変更（従来は値の有無のみで判定していたため、未来日が入った行が実現済み扱いされていた）
- 絞り込みUIに **請求〆日（from〜to）** と **実現日（from〜to）** の範囲指定を追加
- 一覧「実現日」カラムの表示を判定ロジックに整合させ、未来日は「実現予定」として別表示

## 判定ロジック

| `_realized_at` の状態 | フィルタ「未実現」 | フィルタ「実現済み」 | カラム表示 |
|---|---|---|---|
| 空 / 未設定 | 含む | 含まない | 〆日超過ならオレンジ、それ以外は「未実現」 |
| `> 今日`（将来予定） | 含む | 含まない | 灰色「実現予定 + 日付」 |
| `<= 今日` | 含まない | 含む | 緑文字で日付（実現済み） |

## 範囲指定

- `meta_query` で `BETWEEN` / `>=` / `<=` を組み立て
- `_capture_at` / `_realized_at` 個別に from / to を入力可能（片方だけでも可）
- `type => 'DATE'` で文字列比較ではなく日付比較

## Test plan
- [ ] 「未実現の取引」を選ぶと、`_realized_at` が空のものに加え、未来日が入っているものも一覧に出る
- [ ] 「実現済みの取引」を選ぶと、`_realized_at` が今日以前のものだけが出る
- [ ] 請求〆日 from=2026-04-01 / to=2026-04-30 で4月分のみ表示
- [ ] 実現日 from のみ・to のみの片側入力でも絞り込まれる
- [ ] 統計表示は絞り込み後の集計に追従する
- [ ] 一覧の「実現日」カラムで、未来日は「実現予定」表示、過去日/今日は緑日付

🤖 Generated with [Claude Code](https://claude.com/claude-code)