### PR TITLE
Fix: .distignore の wordpress を行頭アンカーする

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -20,7 +20,7 @@ phpstan-bootstrap.php
 phpunit.xml.dist
 README.md
 webpack.config.js
-wordpress
+/wordpress
 bin
 tests
 hanmoto-helper.php.bak

--- a/hanmoto-helper.php
+++ b/hanmoto-helper.php
@@ -46,7 +46,7 @@ function hanmoto_root_dir() {
  */
 function hanmoto_plugin_init() {
 	// Load translations.
-	load_plugin_textdomain( 'hanmoto', true, basename( __DIR__ ) . '/languages' );
+	load_plugin_textdomain( 'hanmoto', false, basename( __DIR__ ) . '/languages' );
 	// Hooks
 	require_once __DIR__ . '/hooks/shortcode.php';
 	// Functions.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,12 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: '#^Parameter \#2 \$deprecated of function load_plugin_textdomain expects string\|false, true given\.$#'
-			identifier: argument.type
-			count: 1
-			path: hanmoto-helper.php
-
-		-
 			message: '#^Function hanmoto_rakuten_product\(\) should return array\|WP_Error but return statement is missing\.$#'
 			identifier: return.missing
 			count: 1


### PR DESCRIPTION
## 背景

`.distignore` は `.gitignore` と同様に、行頭スラッシュなしのパターンは全階層に再帰マッチします。そのため `wordpress` と書くと、将来的に `vendor/**/wordpress` などルート直下以外のパスまで誤って配布物から除外してしまう恐れがあります。ルート直下のディレクトリのみを除外したい場合は、行頭にスラッシュを付けてアンカーする必要があります。

## 変更内容

- `.distignore` の `wordpress` を `/wordpress` に変更し、ルート直下のみにマッチするようアンカーしました。
- `.wordpress-org` など他の行は対象外です。